### PR TITLE
Fixes to get kore 4.1.0 building in Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,4 @@ RUN kodev clean && kodev build
 EXPOSE 8080
 
 # Set the entrypoint
-# ENTRYPOINT ["./wait-for-couchbase.sh", "kodev", "run"]
-ENTRYPOINT ["./wait-for-couchbase.sh", "kore", "-f", "-n", "-r", "-c", "/try-cb-lcb/conf/try-cb-lcb.conf"]
+ENTRYPOINT ["./wait-for-couchbase.sh", "kodev", "run"]

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See [Kore.io] documentation for more details on various ways to run the server. 
 For example, the following commmand will run the `backend` server as a foreground process in DEBUG mode all log output will be visible in the terminal console:
 
 ```
-CB_HOST=127.0.0.1 CB_USER=raycardillo CB_PSWD=raycardillo ./dev-run.sh
+CB_HOST=127.0.0.1 CB_USER=raycardillo CB_PSWD=raycardillo ./run-dev.sh
 ```
 
 To stop the server press <kbd>Control</kbd>+<kbd>C</kbd> in the terminal and wait for the server to gracefully shutdown.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ You may also want to consider [Running All Components Manually](#running-all-com
 
 ## Running with Docker Compose
 
-> WARNING: This is a new repository and the Docker configuration needs more work. Do not use any Docker instructions for this project until the issues are fixed and this comment is removed.
-
 You will need [Docker] installed on your machine in order to run this application as we have defined a [_Dockerfile_](Dockerfile) and a [_docker-compose.yml_](docker-compose.yml) to orchestrate all three of the [Server Layer Components](#server-layer-components).
 
 Running with Docker Compose is as simple as running:
@@ -76,8 +74,6 @@ To end the application press <kbd>Control</kbd>+<kbd>C</kbd> in the terminal and
 
 
 ## Mix and Match Services
-
-> WARNING: This is a new repository and the Docker configuration needs more work. Do not use any Docker instructions for this project until the issues are fixed and this comment is removed.
 
 Instead of running all services, you can start any combination of `backend`,`frontend`, `db` via Docker, and take responsibility for starting the other services yourself.
 

--- a/conf/build.conf
+++ b/conf/build.conf
@@ -4,7 +4,7 @@
 # The flags below are shared between flavors
 cflags=-std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -Wall -Wpedantic -Wextra -Wshadow
 
-ldflags=-lcouchbase -ljwt
+ldflags=-lcouchbase -ljwt -luuid
 
 # Mime types for assets served via the builtin asset_serve_*
 #mime_add=txt:text/plain; charset=utf-8

--- a/conf/try-cb-lcb.conf
+++ b/conf/try-cb-lcb.conf
@@ -1,11 +1,13 @@
 # try-cb-lcb configuration
 
 server notls {
-    bind 127.0.0.1 8080
+    bind 0.0.0.0 8080
     tls no
 }
 
 load ./try-cb-lcb.so
+
+seccomp_tracing yes
 
 domain * {
     attach      notls

--- a/conf/try-cb-lcb.conf
+++ b/conf/try-cb-lcb.conf
@@ -21,7 +21,7 @@ domain * {
 
     route  /  tcblcb_page_index
 
-	route  /apidocs  asset_serve_swagger_json
+    route  /apidocs  asset_serve_swagger_json
 
     route  /api/airports  tcblcb_api_airports
     params qs:get /api/airports {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,13 @@ services:
     container_name: couchbase-sandbox-7.0.0
     ports:
       - "8091-8095:8091-8095"
+      - "9102:9102"
       - "11210:11210"
     expose: # expose ports 8091 & 8094 to other containers (mainly for backend)
       - "8091"
+      - "8092"
+      - "8093"
       - "8094"
+      - "8095"
+      - "9102"
+      - "11210"

--- a/src/try-cb-lcb.c
+++ b/src/try-cb-lcb.c
@@ -22,6 +22,24 @@
 
 #include "try-cb-lcb.h"
 #include "util.h"
+#include <kore/seccomp.h>
+
+// syscalls required by libcouchbase
+// See https://docs.kore.io/4.1.0/api/seccomp.html
+// List of syscalls retrieved by running with `seccomp_tracing yes` in config.
+KORE_SECCOMP_FILTER("try-cb-lcb",
+    KORE_SYSCALL_ALLOW(getgid),
+    KORE_SYSCALL_ALLOW(getegid),
+    KORE_SYSCALL_ALLOW(epoll_create1),
+    KORE_SYSCALL_ALLOW(pipe2),
+    KORE_SYSCALL_ALLOW(uname),
+    KORE_SYSCALL_ALLOW(socket),
+    KORE_SYSCALL_ALLOW(connect),
+    KORE_SYSCALL_ALLOW(getsockname),
+    KORE_SYSCALL_ALLOW(getpeername),
+    KORE_SYSCALL_ALLOW(sendmsg),
+    KORE_SYSCALL_ALLOW(recvmsg),
+)
 
 _Thread_local lcb_INSTANCE *_tcblcb_lcb_instance = NULL;
 

--- a/src/try-cb-lcb.c
+++ b/src/try-cb-lcb.c
@@ -22,6 +22,8 @@
 
 #include "try-cb-lcb.h"
 #include "util.h"
+
+#if defined(__linux__)
 #include <kore/seccomp.h>
 
 // syscalls required by libcouchbase
@@ -40,6 +42,7 @@ KORE_SECCOMP_FILTER("try-cb-lcb",
     KORE_SYSCALL_ALLOW(sendmsg),
     KORE_SYSCALL_ALLOW(recvmsg),
 )
+#endif /* linux */
 
 _Thread_local lcb_INSTANCE *_tcblcb_lcb_instance = NULL;
 

--- a/src/try-cb-lcb.c
+++ b/src/try-cb-lcb.c
@@ -41,6 +41,7 @@ KORE_SECCOMP_FILTER("try-cb-lcb",
     KORE_SYSCALL_ALLOW(getpeername),
     KORE_SYSCALL_ALLOW(sendmsg),
     KORE_SYSCALL_ALLOW(recvmsg),
+    KORE_SYSCALL_ALLOW(gettimeofday),
 )
 #endif /* linux */
 

--- a/wait-for-couchbase.sh
+++ b/wait-for-couchbase.sh
@@ -108,4 +108,5 @@ wait-for $ATTEMPTS \
   '. | del(.indexer) | del(.["travel-sample:def_name_type"]) | map(.items_count > 0) | all' \
   '. | del(.indexer) | map(.num_pending_requests == 0) | all'
 
+set -x
 exec $@


### PR DESCRIPTION
This now builds in Docker (e.g. Ubuntu) with the same version 4.1.0 that's built on OSX (though without pgsql support) but spews following error on starting in dev mode:

```
root@e9e0490aaf3c:/try-cb-lcb# kodev run
building try-cb-lcb (dev)
CFLAGS=-std=c11 -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=700 -Wall -Wpedantic -Wextra -Wshadow -fPIC -Isrc -Isrc/includes -I/usr/local/include  -g -DDEBUG
LDFLAGS=-lcouchbase -ljwt -luuid -shared
nothing to be done!
[parent]: notls serving http on 127.0.0.1:8080
[parent]: privsep: no root path set, using working directory
[parent]: privsep: will not change user
[parent]: privsep: no keymgr_root set, using 'root` directory
[parent]: privsep: will not chroot
[parent]: kore is starting up
[parent]: seccomp sandbox enabled
[parent]: Couchbase Connection: couchbase://db
[parent]: Couchbase Username: Administrator
[wrk 4]: worker 4 started (cpu#4, pid#5030)
[parent]: worker [wrk 4] (5030) exited with status 31
[parent]: worker 4 (pid: 5030) (hdlr: none) gone
[parent]: worker 4 died from sandbox violation
[parent]: restarting worker 4
...
```

Running the prod script instead fails with
`kore: configuration error on line 4`